### PR TITLE
fix: prevent first-character duplication on Dia browser omnibox (closes #172)

### DIFF
--- a/App/PHTV/Context/PHTVAppDetectionService.swift
+++ b/App/PHTV/Context/PHTVAppDetectionService.swift
@@ -252,11 +252,19 @@ final class PHTVAppDetectionService: NSObject {
     // Coc Coc's Chromium UI can expose suggestion/search inputs as plain text fields.
     // Use stricter address-bar detection there to avoid applying omnibox fixes to
     // unrelated browser search/history fields.
+    //
+    // Note: Dia (`company.thebrowser.dia`) was removed from this list — its Cmd+T
+    // command bar exposes role `AXTextArea` with `AXIdentifier=commandBarTextField`
+    // outside any `AXWebArea`, with no positive keyword match in title/description.
+    // Strict mode forced the `default` branch in `addressBarClassification` to
+    // return `false`, so the SendEmptyCharacter+1 omnibox fix never ran on the
+    // first focus → first character was duplicated (e.g., `trần` → `traần`).
+    // Removing Dia here restores the standard non-strict path used by Chrome,
+    // Edge, etc. Dia does not appear to surface Coc Coc-style suggestion text
+    // fields, so this is safe.
     private static let strictAddressBarDetectionApps = BundlePatternSet([
         "com.coccoc.browser",
-        "com.coccoc.browser.app.*",
-        "company.thebrowser.dia",
-        "company.thebrowser.dia.app.*"
+        "com.coccoc.browser.app.*"
     ])
 
     private static let disableVietnameseApps = BundlePatternSet([


### PR DESCRIPTION
Closes #172

## Tóm tắt

Loại `company.thebrowser.dia` khỏi `strictAddressBarDetectionApps`. Strict mode đang phân loại sai ô Cmd+T command bar của Dia (role `AXTextArea`, `AXIdentifier=commandBarTextField`, không match positive keyword) là không-phải-address-bar → omnibox fix `SendEmptyCharacter+1` không kích hoạt → backspace plain bị command bar Dia bỏ qua trên session đầu → ký tự đầu nhân đôi (`trần` → `traần`).

Sau diff: Dia rơi vào nhánh non-strict (giống Chrome/Edge/Brave) → `default` case của `addressBarClassification` trả `true` → omnibox fix apply → backspace được tiêu thụ đúng.

Coc Coc giữ nguyên trong strict list — vẫn cần phân loại bảo thủ cho suggestion/history fields.

## Root cause (trace từ instrumentation)

AX dump tại `PHTVAccessibilityService.isFocusedElementAddressBar()` cho ô Cmd+T của Dia:

```
role     = AXTextArea
title    = <nil>
desc     = <nil>
ident    = commandBarTextField
posKw    = false
webArea  = false
strict   = true        ← bug
→ isAddrBar = false    ← bug
```

Nhánh trong [`addressBarClassification`](App/PHTV/System/PHTVAccessibilityService.swift):

```swift
if positiveKeywordMatch { return true }
if foundWebArea { return false }
switch role {
case "AXComboBox": return true
case "AXTextField", "AXSearchField": return !strictDetection
default: return !strictDetection      // ← AXTextArea rơi vào nhánh này
}
```

Với `strict=true`, `default` case trả `false`. Sau diff: `strict=false` → trả `true` → omnibox fix apply.

## Files changed

- `App/PHTV/Context/PHTVAppDetectionService.swift` (1 file, +11/-3 dòng — gồm comment giải thích lý do)

## Test (cục bộ — Apple M1, macOS 26.x, Telex/Unicode, Z/F/W/J ON)

- [x] Dia Cmd+T: `traafn traafn` → `trần trần` (5/5 pass)
- [x] Dia Cmd+T: `hooong hooong` → `hồng hồng` (5/5 pass)
- [x] Chrome (control) — không regression
- [x] Safari (control) — không regression
- [ ] Coc Coc — chưa test do chưa cài; **không bị ảnh hưởng** vì Coc Coc vẫn nằm trong strict list

## Limitations

- Test chỉ trên Apple Silicon / macOS 26.x. Chưa test Intel.
- Không thêm unit test (codebase chưa có test suite cho `addressBarClassification` ở tầng AX behavior). Nếu maintainer muốn, có thể bổ sung snapshot test cho pure function `addressBarClassification(role:positiveKeywordMatch:foundWebArea:strictDetection:)` — đơn giản vì input/output thuần.

## Future-proof option (khuyến nghị thêm sau, không bắt buộc)

Thêm match positive cho `AXIdentifier == "commandBarTextField"` trong `containsAddressBarKeyword`, để phòng trường hợp Dia cần thêm lại vào strict list trong tương lai vì lý do khác.

## Self-build release

Đã publish self-build tại fork để verify trên môi trường thật:
- Tag: [`v2.9.9-fix`](https://github.com/bechou0410/PHTV/releases/tag/v2.9.9-fix)
- Branch: [`fix/dia-omnibox-first-char`](https://github.com/bechou0410/PHTV/tree/fix/dia-omnibox-first-char)